### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/demo_ci.yml
+++ b/.github/workflows/demo_ci.yml
@@ -57,7 +57,7 @@ jobs:
      steps:
       - uses: actions/checkout@master
       - name: Create a Release
-        uses: elgohr/Github-Release-Action@master
+        uses: elgohr/Github-Release-Action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         with:


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore